### PR TITLE
Added CSV export format

### DIFF
--- a/src/SubmittedManyFormField.php
+++ b/src/SubmittedManyFormField.php
@@ -76,7 +76,7 @@ class SubmittedManyFormField extends SubmittedFormField
      */
     public function getExportValue()
     {
-        return $this->Value;
+        return $this->renderWith('Includes/SubmittedManyFormFieldExport');
     }
 
 

--- a/templates/Includes/SubmittedManyFormFieldExport.ss
+++ b/templates/Includes/SubmittedManyFormFieldExport.ss
@@ -1,0 +1,2 @@
+<% loop $Rows %><% if $HeaderRow %><% loop $Columns %>$Title<% if not $IsLast %>  |  <% end_if %><% end_loop %><% end_if %>
+<% loop $Columns %>$FormattedValue<% if not $IsLast %>  |  <% end_if %><% end_loop %><% end_loop %>


### PR DESCRIPTION
Added an export template for when a submission is exported to CSV via the CMS button.

**Before:**
<img width="731" alt="Screenshot 2024-04-24 at 11 10 49@2x" src="https://github.com/fullscreeninteractive/silverstripe-manyfield/assets/329880/febe2319-7703-4172-a967-6fb218697f14">

**After:**
<img width="458" alt="Screenshot 2024-04-24 at 11 10 58@2x" src="https://github.com/fullscreeninteractive/silverstripe-manyfield/assets/329880/e1dade70-73e3-4e4f-a45d-ea0ccc5215b0">

(Note, due to a [bug in Userforms](https://github.com/silverstripe/silverstripe-userforms/issues/628), this is currently only utilised when an individual submission is exported, and not in an export of **all** submissions).